### PR TITLE
Add required dependency

### DIFF
--- a/prepare-ghcjs.cabal
+++ b/prepare-ghcjs.cabal
@@ -47,5 +47,6 @@ executable prepare-ghcjs
                       , turtle
                       , text
                       , system-filepath
+                      , rawstring-qm
   hs-source-dirs:       src
   default-language:     Haskell2010


### PR DESCRIPTION
This allows the executable to build, which especially helps for CI.