### PR TITLE
Add missing rawstring-qm dependency

### DIFF
--- a/prepare-ghcjs.cabal
+++ b/prepare-ghcjs.cabal
@@ -46,6 +46,7 @@ executable prepare-ghcjs
                       , prepare-ghcjs
                       , turtle
                       , text
+                      , rawstring-qm
                       , system-filepath
   hs-source-dirs:       src
   default-language:     Haskell2010


### PR DESCRIPTION
It is required by `prepare-ghcjs` executable
               
    /tmp/prepare-ghcjs/src/Main.hs:7:1: error:
        Failed to load interface for ‘Data.String.QM’
        It is a member of the hidden package ‘rawstring-qm-0.2.2.2’.
        Perhaps you need to add ‘rawstring-qm’ to the build-depends in your .cabal file.
        Use -v to see a list of the files searched for.
